### PR TITLE
Extract EPM launch logic into platform-specific classes

### DIFF
--- a/src/library/EndpointManagement/EndpointManagerLauncherBase.cs
+++ b/src/library/EndpointManagement/EndpointManagerLauncherBase.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.BridgeToKubernetes.Common;
+using Microsoft.BridgeToKubernetes.Common.IO;
+using Microsoft.BridgeToKubernetes.Common.Logging;
+using System.Threading;
+using System;
+using static Microsoft.BridgeToKubernetes.Common.Constants;
+using System.Collections.Generic;
+
+namespace Microsoft.BridgeToKubernetes.Library.EndpointManagement
+{
+    internal abstract class EndpointManagerLauncherBase : IEndpointManagerLauncher
+    {
+        protected readonly IEnvironmentVariables _environmentVariables;
+        protected readonly IFileSystem _fileSystem;
+        protected readonly ILog _log;
+        protected IOperationContext _operationContext;
+        protected IPlatform _platform;
+        protected readonly string _executableName;
+        protected readonly string _launcherPath;
+
+        protected EndpointManagerLauncherBase(
+            IEnvironmentVariables environmentVariables,
+            IFileSystem fileSystem,
+            ILog log,
+            IOperationContext operationContext,
+            IPlatform platform,
+            bool isWindows)
+        {
+            _environmentVariables = environmentVariables;
+            _fileSystem = fileSystem;
+            _log = log;
+            _operationContext = operationContext;
+            _platform = platform;
+            _executableName = $"{EndpointManager.ProcessName}{(isWindows ? ".exe" : string.Empty)}";
+            _launcherPath = _fileSystem.Path.Combine(_fileSystem.Path.GetExecutingAssemblyDirectoryPath(), EndpointManager.DirectoryName, _executableName);
+        }
+
+        public abstract void LaunchEndpointManager(string currentUserName, string socketFilePath, string logFileDirectory, CancellationToken cancellationToken);
+
+        protected void EnsureLauncherExists()
+        {
+            if (!_fileSystem.FileExists(_launcherPath))
+            {
+                throw new InvalidOperationException($"Failed to find '{_launcherPath}'.");
+            }
+        }
+
+        protected int LaunchExecutable(string executable, string command, CancellationToken cancellationToken)
+        {
+            var envVars = GetEnvironmentVariables();
+            return _platform.Execute(
+                executable: executable,
+                command: command,
+                logCallback: (line) => _log.Info($"Launch output: {line}"),
+                envVariables: envVars,
+                timeout: TimeSpan.FromSeconds(120),
+                cancellationToken: cancellationToken,
+                out string _);
+        }
+
+        private Dictionary<string, string> GetEnvironmentVariables()
+        {
+            if (!string.IsNullOrEmpty(_environmentVariables.DotNetRoot))
+            {
+                _log.Info("Setting the '{0}' environment variable with '{1}' while launching '{2}'.", EnvironmentVariables.Names.DotNetRoot, _environmentVariables.DotNetRoot, EndpointManager.ProcessName);
+                return new Dictionary<string, string>() { { EnvironmentVariables.Names.DotNetRoot, _environmentVariables.DotNetRoot } };
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/library/EndpointManagement/IEndpointManagerLauncher.cs
+++ b/src/library/EndpointManagement/IEndpointManagerLauncher.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading;
+
+namespace Microsoft.BridgeToKubernetes.Library.EndpointManagement
+{
+    public interface IEndpointManagerLauncher
+    {
+        void LaunchEndpointManager(string currentUserName, string socketFilePath, string logFileDirectory, CancellationToken cancellationToken);
+    }
+}

--- a/src/library/EndpointManagement/LinuxEndpointManagerLauncher.cs
+++ b/src/library/EndpointManagement/LinuxEndpointManagerLauncher.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.BridgeToKubernetes.Common;
+using Microsoft.BridgeToKubernetes.Common.Exceptions;
+using Microsoft.BridgeToKubernetes.Common.IO;
+using Microsoft.BridgeToKubernetes.Common.Logging;
+using System;
+using System.Threading;
+using static Microsoft.BridgeToKubernetes.Common.Constants;
+
+namespace Microsoft.BridgeToKubernetes.Library.EndpointManagement
+{
+    internal class LinuxEndpointManagerLauncher : EndpointManagerLauncherBase
+    {
+        public LinuxEndpointManagerLauncher(
+            IEnvironmentVariables environmentVariables,
+            IFileSystem fileSystem,
+            ILog log,
+            IOperationContext operationContext,
+            IPlatform platform) : base(
+                environmentVariables,
+                fileSystem,
+                log,
+                operationContext,
+                platform,
+                false)
+        {
+        }
+
+        public override void LaunchEndpointManager(string currentUserName, string socketFilePath, string logFileDirectory, CancellationToken cancellationToken)
+        {
+            EnsureLauncherExists();
+
+            var quotedLaunchPathAndArguments = $"\\\"{_launcherPath}\\\" \\\"{currentUserName}\\\" \\\"{socketFilePath}\\\" \\\"{logFileDirectory}\\\" \\\"{_operationContext.CorrelationId}\\\"";
+
+            // Try to use pkexec to show a GUI prompt for the user's password so we can run EndpointManager as root.
+            // If we are already running as root, then pkexec will not show a prompt.
+            // When running in Codespaces the user is setup to run sudo without needing to enter password.
+            var fileName = _environmentVariables.IsCodespaces ? "sudo" : "pkexec";
+            var command = $"env HOME=\"{_fileSystem.HomeDirectoryPath}\" bash -c \"{quotedLaunchPathAndArguments} &> /dev/null &\"";
+
+            _log.Info($"Launch {EndpointManager.ProcessName}: {fileName} {command}");
+            var launchExitCode = LaunchExecutable(fileName, command, cancellationToken);
+
+            if (launchExitCode == 126)
+            {
+                // User cancellation
+                throw new InvalidUsageException(_log.OperationContext, Resources.LaunchProcessCancelled, EndpointManager.ProcessName);
+            }
+
+            // pkexec allows an authorized user to execute PROGRAM as another user. Refer - https://linux.die.net/man/1/pkexec
+            // if pkexec failed then launchExitCode will not be zero, so giving user another chance to try with sudo. 
+            // But this might fail for users who don't have sudo access. This is specifically for Linux.
+            if (launchExitCode != 0 && !_environmentVariables.IsCodespaces)
+            {
+                _log.Info($"pkexec failed with exitCode {launchExitCode}, retrying with sudo");
+                fileName = "sudo"; // replace pkexec with sudo
+                _log.Info($"Launch {EndpointManager.ProcessName}: {fileName} {command}");
+                launchExitCode = LaunchExecutable(fileName, command, cancellationToken);
+            }
+
+            if (launchExitCode != 0)
+            {
+                throw new InvalidOperationException($"{EndpointManager.ProcessName} exited with exit code {launchExitCode}");
+            }
+        }
+    }
+}

--- a/src/library/EndpointManagement/OsxEndpointManagerLauncher.cs
+++ b/src/library/EndpointManagement/OsxEndpointManagerLauncher.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.BridgeToKubernetes.Common;
+using Microsoft.BridgeToKubernetes.Common.Exceptions;
+using Microsoft.BridgeToKubernetes.Common.IO;
+using Microsoft.BridgeToKubernetes.Common.Logging;
+using System;
+using System.Text;
+using System.Threading;
+using static Microsoft.BridgeToKubernetes.Common.Constants;
+
+namespace Microsoft.BridgeToKubernetes.Library.EndpointManagement
+{
+    internal class OsxEndpointManagerLauncher : EndpointManagerLauncherBase
+    {
+        public OsxEndpointManagerLauncher(
+            IEnvironmentVariables environmentVariables,
+            IFileSystem fileSystem,
+            ILog log,
+            IOperationContext operationContext,
+            IPlatform platform) : base(
+                environmentVariables,
+                fileSystem,
+                log,
+                operationContext,
+                platform,
+                false)
+        {
+        }
+
+        public override void LaunchEndpointManager(string currentUserName, string socketFilePath, string logFileDirectory, CancellationToken cancellationToken)
+        {
+            EnsureLauncherExists();
+
+            var quotedLaunchPathAndArguments = $"\\\\\\\"{_launcherPath}\\\\\\\" \\\\\\\"{currentUserName}\\\\\\\" \\\\\\\"{socketFilePath}\\\\\\\" \\\\\\\"{logFileDirectory}\\\\\\\" \\\\\\\"{_operationContext.CorrelationId}\\\\\\\"";
+
+            // We launch the EPM using AppleScript when on OSX.
+            var fileName = "/usr/bin/osascript";
+
+            // Tell the shell to redirect output so that this process exits and the EPM continues to run in the background
+            // For more info: https://developer.apple.com/library/archive/technotes/tn2065/_index.html#//apple_ref/doc/uid/DTS10003093-CH1-TNTAG5-I_WANT_TO_START_A_BACKGROUND_SERVER_PROCESS__HOW_DO_I_MAKE_DO_SHELL_SCRIPT_NOT_WAIT_UNTIL_THE_COMMAND_COMPLETES_
+            StringBuilder commandBuilder = new StringBuilder();
+            commandBuilder.Append("-e \"do shell script ");
+            commandBuilder.Append($"\\\"{quotedLaunchPathAndArguments} &> /dev/null &\\\"");
+            commandBuilder.Append($" with prompt \\\"{Product.Name} wants to launch {EndpointManager.ProcessName}.\\\" with administrator privileges\"");
+            var command = commandBuilder.ToString();
+
+            _log.Info($"Launch {EndpointManager.ProcessName}: {fileName} {command}");
+            var launchExitCode = LaunchExecutable(fileName, command, cancellationToken);
+
+            if (launchExitCode == 1)
+            {
+                // User cancellation
+                throw new InvalidUsageException(_log.OperationContext, Resources.LaunchProcessCancelled, EndpointManager.ProcessName);
+            }
+
+            if (launchExitCode != 0)
+            {
+                throw new InvalidOperationException($"{EndpointManager.ProcessName} exited with exit code {launchExitCode}");
+            }
+        }
+    }
+}

--- a/src/library/EndpointManagement/WindowsEndpointManagerLauncher.cs
+++ b/src/library/EndpointManagement/WindowsEndpointManagerLauncher.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.BridgeToKubernetes.Common;
+using System.Diagnostics;
+using Microsoft.BridgeToKubernetes.Common.IO;
+using static Microsoft.BridgeToKubernetes.Common.Constants;
+using Microsoft.BridgeToKubernetes.Common.Logging;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.ComponentModel;
+using System;
+using Microsoft.BridgeToKubernetes.Common.Exceptions;
+
+namespace Microsoft.BridgeToKubernetes.Library.EndpointManagement
+{
+    internal class WindowsEndpointManagerLauncher : EndpointManagerLauncherBase
+    {
+        public WindowsEndpointManagerLauncher(
+            IEnvironmentVariables environmentVariables,
+            IFileSystem fileSystem,
+            ILog log,
+            IOperationContext operationContext,
+            IPlatform platform) : base(
+                environmentVariables,
+                fileSystem,
+                log,
+                operationContext,
+                platform,
+                true)
+        {
+        }
+
+        public override void LaunchEndpointManager(string currentUserName, string socketFilePath, string logFileDirectory, CancellationToken cancellationToken)
+        {
+            EnsureLauncherExists();
+
+            // Since EndpointManager is started as an elevated process and when a DOTNET_ROOT env variable is set,
+            // on windows it is not possible to pass the DOTNET_ROOT value, so using EndpointManagerLauncher to start EndpointManager.
+            // When VSCode uses BinariesV2 strategy to download clients, DOTNET_ROOT env var is set.
+            var processStartInfo = string.IsNullOrEmpty(_environmentVariables.DotNetRoot)
+                ? GetEndpointManagerLaunchInfoStandard(currentUserName, socketFilePath, logFileDirectory)
+                : GetEndpointManagerLaunchInfoForDotnetRoot(currentUserName, socketFilePath, logFileDirectory);
+
+            try
+            {
+                // Note: If the UAC prompt is declined, the process will throw a Win32Exception.
+                Process.Start(processStartInfo);
+            }
+            catch (Exception ex) when (ex is Win32Exception)
+            {
+                // This catch block will be hit if the user declines the UAC prompt on Windows.
+                // However, since potential other Win32Exceptions could arise, we log the exception as a warning.
+                _log.ExceptionAsWarning(ex);
+                throw new InvalidUsageException(_log.OperationContext, ex, Resources.LaunchProcessCancelled, EndpointManager.ProcessName);
+            }
+        }
+
+        private ProcessStartInfo GetEndpointManagerLaunchInfoForDotnetRoot(string currentUserName, string socketFilePath, string logFileDirectory)
+        {
+            var epmLauncherPath = _fileSystem.Path.Combine(_fileSystem.Path.GetExecutingAssemblyDirectoryPath(), EndpointManager.LauncherDirectoryName, _executableName);
+            var quotedArguments = $"\"{_environmentVariables.DotNetRoot.Trim('"')}\" \"{_launcherPath}\" \"{currentUserName}\" \"{socketFilePath}\" \"{logFileDirectory}\" \"{_operationContext.CorrelationId}\"";
+            return GetEndpointManagerLaunchInfo(epmLauncherPath, quotedArguments);
+        }
+
+        private ProcessStartInfo GetEndpointManagerLaunchInfoStandard(string currentUserName, string socketFilePath, string logFileDirectory)
+        {
+            var quotedArguments = $"\"{currentUserName}\" \"{socketFilePath}\" \"{logFileDirectory}\" \"{_operationContext.CorrelationId}\"";
+            return GetEndpointManagerLaunchInfo($"\"{_launcherPath}\"", quotedArguments);
+        }
+
+        private ProcessStartInfo GetEndpointManagerLaunchInfo(string launcherPath, string quotedArguments)
+        {
+            _log.Trace(EventLevel.Informational, $"Launcher path: {launcherPath} quotedArguments: {quotedArguments}");
+            // Start launcher as admin
+            ProcessStartInfo psi = new ProcessStartInfo()
+            {
+                FileName = launcherPath,
+                Arguments = quotedArguments,
+                UseShellExecute = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                Verb = "runas"
+            };
+
+            return psi;
+        }
+    }
+}


### PR DESCRIPTION
This attempts to place the platform-specific logic close together, so that the calling code (in `EnsureEndpointManagerRunningAsync`) doesn't need to behave conditionally depending on the platform.

It is also a step in the direction of making this testable, because the hard-to-test platform specific features are abstracted behind an interface that can be mocked.